### PR TITLE
Update lab7.rst

### DIFF
--- a/1_Introduction/module1/lab7.rst
+++ b/1_Introduction/module1/lab7.rst
@@ -92,7 +92,7 @@ Perform the following steps to complete this task:
    system assumes you want to add an entry in the transaction
    queue. You MUST remove this header if you want to issue
    transaction queue changes (like deleting an entry from the
-   queue, changing the order, commiting a transaction). if you
+   queue, changing the order, commiting a transaction). If you
    don't remove the header in that specific case, the system 
    will send a 400 with the following type of error:
    "message": "Transaction XXXXX operation .... is not allowed

--- a/1_Introduction/module1/lab7.rst
+++ b/1_Introduction/module1/lab7.rst
@@ -87,3 +87,13 @@ Perform the following steps to complete this task:
 .. |image40| image:: /_static/image040.png
    :width: 6.37328in
    :height: 2.45058in
+
+#. when sending the Header ``X-F5-REST-Coordination-Id``, the
+   system assumes you want to add an entry in the transaction
+   queue. You MUST remove this header if you want to issue
+   transaction queue changes (like deleting an entry from the
+   queue, changing the order, commiting a transaction). if you
+   don't remove the header in that specific case, the system 
+   will send a 400 with the following type of error:
+   "message": "Transaction XXXXX operation .... is not allowed
+   to be added to transaction."

--- a/1_Introduction/module1/lab7.rst
+++ b/1_Introduction/module1/lab7.rst
@@ -88,7 +88,7 @@ Perform the following steps to complete this task:
    :width: 6.37328in
    :height: 2.45058in
 
-#. when sending the Header ``X-F5-REST-Coordination-Id``, the
+:warning: When sending the Header ``X-F5-REST-Coordination-Id``, the
    system assumes you want to add an entry in the transaction
    queue. You MUST remove this header if you want to issue
    transaction queue changes (like deleting an entry from the


### PR DESCRIPTION
if you keep the X-F5-REST-Coordination-Id in the headers for PATCH commands, it fails, as the system assumes you want to send a new command to a transaction queue, instead of evaluating the change you want to do in the existing queu (like DELETE, change the eval order, COMMIT, ...)