### PR TITLE
Develop

### DIFF
--- a/docs/class2/module1/lab3.rst
+++ b/docs/class2/module1/lab3.rst
@@ -20,16 +20,16 @@ Task 1 - Connect via SSH
 To connect to the image via SSH we must use the published port specified in the
 ``docker run`` command.  **To review** the command used to start the container was:
 
-``docker run -p 8080:80 -p 2222:22 -p 10000:8080 --rm -it -e SNOPS_GH_BRANCH=master
-f5devcentral/f5-super-netops-container:jenkins``
+**docker run -p 8080:80 -p 2222:22 -p 10000:8080 --rm -it -e SNOPS_GH_BRANCH=master
+f5devcentral/f5-super-netops-container:jenkins**
 
-This will publish the standard SSH service from ``TCP/22`` to ``TCP/2222``.
+This will publish the standard SSH service from **TCP/22** to **TCP/2222**.
 In the case of the SSH service the following mapping applies:
 
-``localhost:2222 -> f5-super-netops-container:22``
+**localhost:2222 -> f5-super-netops-container:22**
 
-The container includes the ``snops`` user with a password of
-``default``.
+Execute below to SSH into the container includes the ``snops`` user with a
+password of ``default``.
 
 ``ssh -p 2222 snops@localhost``
 
@@ -108,13 +108,13 @@ Task 2 - Connect via HTTP
 To connect to the image via HTTP we use the published port specified in the
 ``docker run`` command.  **To review** the command used to start the container was:
 
-``docker run -p 8080:80 -p 2222:22 -p 10000:8080 --rm -it -e SNOPS_GH_BRANCH=master
-f5devcentral/f5-super-netops-container:jenkins``
+**docker run -p 8080:80 -p 2222:22 -p 10000:8080 --rm -it -e SNOPS_GH_BRANCH=master
+f5devcentral/f5-super-netops-container:jenkins**
 
-This will publish the standard HTTP service from ``TCP/80`` to ``TCP/8080``.
+This will publish the standard HTTP service from **TCP/80** to **TCP/8080**.
 In the case of the HTTP service the following mapping applies:
 
-``localhost:8080 -> f5-super-netops-container:80``
+**localhost:8080 -> f5-super-netops-container:80**
 
 Open Chrome on your Linux Jumphost and enter the URL:
 
@@ -130,13 +130,13 @@ Task 3 - Connect via Jenkins
 To connect to the image via Jenkins we use the published port specified in the
 ``docker run`` command.  **To review** the command used to start the container was:
 
-``docker run -p 8080:80 -p 2222:22 -p 10000:8080 --rm -it -e SNOPS_GH_BRANCH=master
-f5devcentral/f5-super-netops-container:jenkins``
+**docker run -p 8080:80 -p 2222:22 -p 10000:8080 --rm -it -e SNOPS_GH_BRANCH=master
+f5devcentral/f5-super-netops-container:jenkins**
 
-This will publish the standard Jenkins service from ``TCP/8080`` to ``TCP/10000``.
+This will publish the standard Jenkins service from **TCP/8080** to **TCP/10000**.
 In the case of the Jenkins service the following mapping applies:
 
-``10.1.1.8:10000 -> f5-super-netops-container:8080``
+**10.1.1.8:10000 -> f5-super-netops-container:8080**
 
 To connect to Jenkins open a web browser and enter the URL:
 

--- a/docs/class2/module2/lab2.rst
+++ b/docs/class2/module2/lab2.rst
@@ -94,7 +94,7 @@ Execute the following steps to complete this task:
 #. Name the environment ``Lab 2.2`` and populate the following key/value
    pairs:
 
-   - **bigip_mgmt**: 10.1.1.4
+   - **bigip_mgmt**: 10.1.1.10
    - **bigip_username**: admin
    - **bigip_password**: admin
 

--- a/docs/class2/module2/lab3.rst
+++ b/docs/class2/module2/lab3.rst
@@ -103,7 +103,7 @@ precedence.
 
     {
         "globalVars": {
-            "bigip_mgmt": "10.1.1.4",
+            "bigip_mgmt": "10.1.1.10",
             "bigip_username":"admin",
             "bigip_password":"admin"
         }
@@ -178,7 +178,7 @@ Final Workflow JSON
                    "reporters":["cli"]
            },
            "globalVars": {
-                   "bigip_mgmt": "10.1.1.4",
+                   "bigip_mgmt": "10.1.1.10",
                    "bigip_username":"admin",
                    "bigip_password":"admin"
            },

--- a/docs/class2/module2/lab4.rst
+++ b/docs/class2/module2/lab4.rst
@@ -19,13 +19,13 @@ Task 1 - Run a f5-newman-wrapper Workflow
 #. Return to, or open an SSH session as described in the :ref:`previous lab <lab1_3_1>`
 #. Run ``cd f5-postman-workflows/local``
 #. Run ``cp ../workflows/Wrapper_Demo_1.json .``
-#. Edit the ``Wrapper_Demo_1.json`` file with ``vim`` and enter the ``10.1.1.4`` for
+#. Edit the ``Wrapper_Demo_1.json`` file with ``vim`` and enter the ``10.1.1.10`` for
    the value of the ``bigip_mgmt`` variable
 
    .. code:: json
 
         "globalVars": {
-                "bigip_mgmt": "10.1.1.4",
+                "bigip_mgmt": "10.1.1.10",
                 "bigip_username":"admin",
                 "bigip_password":"admin"
         },
@@ -49,18 +49,18 @@ Task 1 - Run a f5-newman-wrapper Workflow
 
         ❏ 1_Authenticate
         ↳ Authenticate and Obtain Token
-          POST https://10.1.1.4/mgmt/shared/authn/login [200 OK, 1.41KB, 108ms]
+          POST https://10.1.1.10/mgmt/shared/authn/login [200 OK, 1.41KB, 108ms]
           ✓  [POST Response Code]=200
           ✓  [Populate Variable] bigip_token=WYKIVPHCNASNVEC55ZDVNH5OO2
 
         ↳ Verify Authentication Works
-          GET https://10.1.1.4/mgmt/shared/authz/tokens/WYKIVPHCNASNVEC55ZDVNH5OO2 [200 OK, 1.23KB, 8ms]
+          GET https://10.1.1.10/mgmt/shared/authz/tokens/WYKIVPHCNASNVEC55ZDVNH5OO2 [200 OK, 1.23KB, 8ms]
           ✓  [GET Response Code]=200
           ✓  [Current Value] token=WYKIVPHCNASNVEC55ZDVNH5OO2
           ✓  [Check Value] token == WYKIVPHCNASNVEC55ZDVNH5OO2
 
         ↳ Set Authentication Token Timeout
-          PATCH https://10.1.1.4/mgmt/shared/authz/tokens/WYKIVPHCNASNVEC55ZDVNH5OO2 [200 OK, 1.23KB, 14ms]
+          PATCH https://10.1.1.10/mgmt/shared/authz/tokens/WYKIVPHCNASNVEC55ZDVNH5OO2 [200 OK, 1.23KB, 14ms]
           ✓  [PATCH Response Code]=200
           ✓  [Current Value] timeout=1200
           ✓  [Check Value] timeout == 1200
@@ -91,7 +91,7 @@ Task 1 - Run a f5-newman-wrapper Workflow
 
         ❏ 4A_Get_BIGIP_Version
         ↳ Get Software Version
-          GET https://10.1.1.4/mgmt/tm/sys/software/volume [200 OK, 1.32KB, 16ms]
+          GET https://10.1.1.10/mgmt/tm/sys/software/volume [200 OK, 1.32KB, 16ms]
           ✓  [GET Response Code]=200
           ✓  [Populate Variable] bigip_version=12.1.1
           ✓  [Populate Variable] bigip_build=1.0.196
@@ -130,7 +130,7 @@ Task 1 - Run a f5-newman-wrapper Workflow
         "values": [
           {
             "type": "any",
-            "value": "10.1.1.4",
+            "value": "10.1.1.10",
             "key": "bigip_mgmt"
           },
           {

--- a/docs/class2/module2/lab5.rst
+++ b/docs/class2/module2/lab5.rst
@@ -61,7 +61,7 @@ have different values for ``bigip_mgmt`` because we are trying to communicate
 with two BIG-IP devices.  To address this issue, we could define our input
 variables as follows:
 
-- ``bigip_a_mgmt = 10.1.1.4``
+- ``bigip_a_mgmt = 10.1.1.10``
 - ``bigip_b_mgmt = 10.1.1.5``
 - ``bigip_username = admin``
 - ``bigip_password = admin``
@@ -78,7 +78,7 @@ device.  To illustrate this, we will add more information to our diagram:
    Start
      |
      |- Define globalVars
-     |  |- bigip_a_mgmt = 10.1.1.4
+     |  |- bigip_a_mgmt = 10.1.1.10
      |  |- bigip_b_mgmt = 10.1.1.5
      |  |- bigip_username = admin
      |  |- bigip_password = admin
@@ -113,7 +113,7 @@ can modify our diagram to handle this issue like this:
    Start
      |
      |- Define globalVars
-     |  |- bigip_a_mgmt = 10.1.1.4
+     |  |- bigip_a_mgmt = 10.1.1.10
      |  |- bigip_b_mgmt = 10.1.1.5
      |  |- bigip_username = admin
      |  |- bigip_password = admin
@@ -145,7 +145,7 @@ variables for each device:
    Start
      |
      |- Define globalVars
-     |  |- bigip_a_mgmt = 10.1.1.4
+     |  |- bigip_a_mgmt = 10.1.1.10
      |  |- bigip_b_mgmt = 10.1.1.5
      |  |- bigip_username = admin
      |  |- bigip_password = admin
@@ -210,7 +210,7 @@ Define Global Settings & Variables:
        "reporters":["cli"]
      },
      "globalVars": {
-       "bigip_a_mgmt": "10.1.1.4",
+       "bigip_a_mgmt": "10.1.1.10",
        "bigip_b_mgmt": "10.1.1.5",
        "bigip_username":"admin",
        "bigip_password":"admin"
@@ -462,7 +462,7 @@ Task 3 - Run the Workflow
 
       {
         "globalVars": {
-                "bigip_a_mgmt": "10.1.1.4",
+                "bigip_a_mgmt": "10.1.1.10",
                 "bigip_b_mgmt": "10.1.1.5",
                 "bigip_username":"admin",
                 "bigip_password":"admin"
@@ -487,18 +487,18 @@ Task 3 - Run the Workflow
 
       ❏ 1_Authenticate
       ↳ Authenticate and Obtain Token
-        POST https://10.1.1.4/mgmt/shared/authn/login [200 OK, 1.41KB, 570ms]
+        POST https://10.1.1.10/mgmt/shared/authn/login [200 OK, 1.41KB, 570ms]
         ✓  [POST Response Code]=200
         ✓  [Populate Variable] bigip_token=UE7W5CXWM5SJ6SZEV5A7KTAI5Q
 
       ↳ Verify Authentication Works
-        GET https://10.1.1.4/mgmt/shared/authz/tokens/UE7W5CXWM5SJ6SZEV5A7KTAI5Q [200 OK, 1.23KB, 9ms]
+        GET https://10.1.1.10/mgmt/shared/authz/tokens/UE7W5CXWM5SJ6SZEV5A7KTAI5Q [200 OK, 1.23KB, 9ms]
         ✓  [GET Response Code]=200
         ✓  [Current Value] token=UE7W5CXWM5SJ6SZEV5A7KTAI5Q
         ✓  [Check Value] token == UE7W5CXWM5SJ6SZEV5A7KTAI5Q
 
       ↳ Set Authentication Token Timeout
-        PATCH https://10.1.1.4/mgmt/shared/authz/tokens/UE7W5CXWM5SJ6SZEV5A7KTAI5Q [200 OK, 1.23KB, 13ms]
+        PATCH https://10.1.1.10/mgmt/shared/authz/tokens/UE7W5CXWM5SJ6SZEV5A7KTAI5Q [200 OK, 1.23KB, 13ms]
         ✓  [PATCH Response Code]=200
         ✓  [Current Value] timeout=1200
         ✓  [Check Value] timeout == 1200
@@ -571,7 +571,7 @@ Task 3 - Run the Workflow
 
       ❏ 4A_Get_BIGIP_Version
       ↳ Get Software Version
-        GET https://10.1.1.4/mgmt/tm/sys/software/volume [200 OK, 1.32KB, 207ms]
+        GET https://10.1.1.10/mgmt/tm/sys/software/volume [200 OK, 1.32KB, 207ms]
         ✓  [GET Response Code]=200
         ✓  [Populate Variable] bigip_version=12.1.1
         ✓  [Populate Variable] bigip_build=1.0.196
@@ -643,7 +643,7 @@ Task 3 - Run the Workflow
         "values": [
           {
             "type": "any",
-            "value": "10.1.1.4",
+            "value": "10.1.1.10",
             "key": "bigip_a_mgmt"
           },
           {

--- a/docs/class2/module3/module3.rst
+++ b/docs/class2/module3/module3.rst
@@ -13,6 +13,13 @@ This also allows BIG-IP to be Orchestrated from upper level orchestration toolki
 Using this structure allows you to build your own solutions, to manage BIG-IP
 quickly as native REST calls are used.
 
+.. NOTE:: If you are running this lab independent from Class 1 you will want
+          to restore BIGIP-A from UCS ``bigip-a-module3.ucs``. Not restoring
+          BIGIP-A will result in services unable to be accessed 
+          and nodes/pool members unavailable. The steps for a UCS restore can
+          be found under the **HOWTos: Index** in the content tree on the left
+          side of the Lab Guide
+
 
 .. toctree::
    :maxdepth: 1

--- a/docs/class2/module3/module3.rst
+++ b/docs/class2/module3/module3.rst
@@ -14,11 +14,11 @@ Using this structure allows you to build your own solutions, to manage BIG-IP
 quickly as native REST calls are used.
 
 .. NOTE:: If you are running this lab independent from Class 1 you will want
-          to restore BIGIP-A from UCS ``bigip-a-module3.ucs``. Not restoring
-          BIGIP-A will result in services unable to be accessed 
-          and nodes/pool members unavailable. The steps for a UCS restore can
-          be found under the **HOWTos: Index** in the content tree on the left
-          side of the Lab Guide
+   to restore BIGIP-A from UCS ``bigip-a-module3.ucs``. Not restoring
+   BIGIP-A will result in services unable to be accessed 
+   and nodes/pool members unavailable. The steps for a UCS restore can
+   be found under the **HOWTos: Index** in the content tree on the left
+   side of the Lab Guide
 
 
 .. toctree::

--- a/docs/howtos/HOWTO_Restore_from_UCS.rst
+++ b/docs/howtos/HOWTO_Restore_from_UCS.rst
@@ -1,0 +1,40 @@
+HOWTO - Restore a BIGIP from UCS
+--------------------------------
+
+This HOWTO document describes the changes required to restore a BIGIP
+in the Lab Environment
+
+Situations from the lab may cause the need to restore a BIGIP, the lab is
+seeded with 3 UCS files per BIGIP (matching the modules) from different
+parts of Class 1.
+
+Credential reminder:
+GUI: **admin\admin**
+SSH: **root\default**
+
+Task 1 - Import the existing UCS into BIG-IP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+UCS files are located in the **in_case_of_emergency** folder on desktop of
+the Linux Jumphost
+
+Complete the following steps:
+
+#. Login to the BIG-IP GUI
+#. Click System -> Archives -> Upload
+#. Click **Choose File** find the desired UCS in the specified folder and open
+#. Click **Upload**
+
+Task 2 - Use TMSH to restore the UCS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because the dynamic license within this environment we must specify the
+``no-license`` flag, which is only available via TMSH commands.
+
+Complete the following steps:
+
+#. Open **Root Terminal** from the Desktop
+#. SSH in the BIGIP needing the UCS restore, example ``ssh root@10.1.1.10``
+#. Issue the ``tmsh`` command to switch shells
+#. To restore the specific UCS file issue the
+``load sys ucs (name_of_ucs) no-license``


### PR DESCRIPTION
THESE ARE ALL CLASS 2 CHANGES

Module 2 has config for 10.1.1.4, causing issues with this section,
since the BIGIP is 10.1.1.10

clean up from ``code`` to **bold** in sections to stop confusion that
it isn’t a command needed, just a note

there is also a new HOWTO for restoring a UCS file, if class2 is run
independent of class1 you won’t have any network connectivity to see
nodes/pool members active. restoring BIGIP A via UCS will solve this