### PR TITLE
class1 minor wording errata

### DIFF
--- a/docs/class1/module1/module1.rst
+++ b/docs/class1/module1/module1.rst
@@ -40,7 +40,7 @@ focus on demonstrating an **Imperative** approach to automation.
 .. NOTE:: The Lab Deployment for this lab includes two BIG-IP devices.
    For most of the labs, we will only be configuring the BIG-IP A
    device (management IP configuration and licensing has been completed).
-   BIG-IP B will have some minimal configuration pre-loaded. In real-world
+   BIG-IP B will have some minimal configuration pre-loaded. In a real-world
    scenario, it would be necessary to perform Device Onboarding functions
    on ALL BIG-IP devices. In this lab exercise, we chose to perform it only
    on a single device due to lab time allocation constraints.

--- a/docs/class1/module2/lab3.rst
+++ b/docs/class1/module2/lab3.rst
@@ -25,7 +25,7 @@ Now that the App Services iApp template is installed, we can deploy a new
 Layer 4 to 7 Service. We will start with **Creating** a Basic HTTP Service,
 demonstrate **Modifying/Mutate** the service by changing the node state,
 and finally **Delete** the whole service. Once we've demonstrated with these
-tasks, we'll introduce more complex deployments options with iRules, Custom
+tasks, we'll introduce more complex deployment options with iRules, Custom
 Profiles, Certificates, and an ASM Policy.
 
 .. NOTE:: This lab work will be performed from
@@ -236,7 +236,7 @@ Perform the following steps to complete this task:
 
 #. iApps are a Declarative interface, allowing us to modify deployment without
    the need to delete it (this also means we can re-name objects **if**
-   we needed too).  For this service we will:
+   we needed to).  For this service we will:
 
    - Use the same custom profiles
    - Remove the iRule

--- a/docs/class1/module3/lab2.rst
+++ b/docs/class1/module3/lab2.rst
@@ -24,7 +24,7 @@ Lab 3.2: Create a Declarative Service Catalog
 
 In the introduction to this module we discussed the importance of using
 **Service Templates** to build a **Declarative Service Catalog**.  This
-lab will show to create a few examples of **Service Templates**
+lab will show how to create a few examples of **Service Templates**
 (Templates).  It's important to understand that while the packaged examples
 used in this lab are great starting points, you should use them as a starting
 point for creating your own **Service Catalog** that meets the requirements of


### PR DESCRIPTION
mod2lab3: deployments options > deployment options,  needed too > needed to
mod3mod3: The labs in the module > The labs in this module
mod3lab2: This lab will show to create > This lab will show how to create