### PR TITLE
fixes for query

### DIFF
--- a/postman_collections/f5-programmability-class-2.postman_collection.json
+++ b/postman_collections/f5-programmability-class-2.postman_collection.json
@@ -213,7 +213,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "https://{{bigip_mgmt}}/mgmt/tm/ltm/pool/~{{bigip_partition}}~{{bigip_vs_name}}~{{bigip_pool_name}}/members/",
+							"raw": "https://{{bigip_mgmt}}/mgmt/tm/ltm/pool/~{{bigip_partition}}~{{bigip_vs_name}}~{{bigip_pool_name}}",
 							"protocol": "https",
 							"host": [
 								"{{bigip_mgmt}}"


### PR DESCRIPTION
pool memebers arent initially installed need to only query for pool, this was causing a 503 error as expected